### PR TITLE
Support parent directory creation for certificates operations

### DIFF
--- a/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/ExportCertificateMojo.java
+++ b/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/ExportCertificateMojo.java
@@ -16,6 +16,7 @@ package org.codehaus.mojo.keytool;
  * limitations under the License.
  */
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.keytool.requests.KeyToolExportCertificateRequest;
@@ -61,6 +62,12 @@ public class ExportCertificateMojo
     public ExportCertificateMojo()
     {
         super( KeyToolExportCertificateRequest.class );
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        createParentDirIfNecessary(file);
+        super.execute();
     }
 
     /**

--- a/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateMojo.java
+++ b/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateMojo.java
@@ -16,6 +16,7 @@ package org.codehaus.mojo.keytool;
  * limitations under the License.
  */
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.shared.utils.cli.Commandline;
@@ -136,6 +137,12 @@ public class GenerateCertificateMojo
     public GenerateCertificateMojo()
     {
         super( KeyToolGenerateCertificateRequest.class );
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        createParentDirIfNecessary(this.outfile.getPath());
+        super.execute();
     }
 
     /**

--- a/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateRequestMojo.java
+++ b/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateRequestMojo.java
@@ -16,6 +16,7 @@ package org.codehaus.mojo.keytool;
  * limitations under the License.
  */
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.shared.utils.cli.Commandline;
@@ -85,6 +86,12 @@ public class GenerateCertificateRequestMojo
     public GenerateCertificateRequestMojo()
     {
         super( KeyToolGenerateCertificateRequestRequest.class );
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        createParentDirIfNecessary(this.file.getPath());
+        super.execute();
     }
 
     /**


### PR DESCRIPTION
Call `AbstractKeyToolRequestWithKeyStoreParametersMojo.createParentDirIfNecessary` in `ExportCertificateMojo`, `GenerateCertificateMojo` and `GenerateCertificateRequestMojo` for issue #9.