### PR TITLE
Allow multiple ext to be specified for GenerateKeyPairMojo, GenerateCertificateRequestMojo, and GenerateCertificateMojo

### DIFF
--- a/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateMojo.java
+++ b/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateMojo.java
@@ -24,6 +24,7 @@ import org.codehaus.mojo.keytool.requests.KeyToolGenerateCertificateRequest;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * To generate certificate from a certificate request from a keystore.
@@ -117,9 +118,22 @@ public class GenerateCertificateMojo
      * See <a href="http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/keytool.html#Commands">options</a>.
      *
      * @since 1.2
+     *
+     * @deprecated Use {@link #exts instead}.
      */
+    @Deprecated
     @Parameter
     private String ext;
+
+    /**
+     * X.509 extension.
+     * <p/>
+     * See <a href="http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/keytool.html#Commands">options</a>.
+     *
+     * @since 1.6
+     */
+    @Parameter
+    private List<String> exts;
 
     /**
      * Validity number of days.
@@ -160,7 +174,11 @@ public class GenerateCertificateMojo
         request.setSigalg( this.sigalg );
         request.setDname( this.dname );
         request.setStartdate( this.startdate );
-        request.setExt( this.ext );
+        if (this.exts != null && !this.exts.isEmpty()) {
+            request.setExts(exts);
+        } else {
+            request.setExt(ext);
+        }
         request.setValidity( this.validity );
         return request;
     }

--- a/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateRequestMojo.java
+++ b/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateCertificateRequestMojo.java
@@ -24,6 +24,9 @@ import org.codehaus.mojo.keytool.requests.KeyToolGenerateCertificateRequestReque
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * To generate certificate request.
@@ -76,9 +79,22 @@ public class GenerateCertificateRequestMojo
      * See <a href="http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/keytool.html#Commands">options</a>.
      *
      * @since 1.6
+     *
+     * @deprecated Use {@link #exts instead}.
      */
+    @Deprecated
     @Parameter
     private String ext;
+
+    /**
+     * X.509 extension.
+     * <p/>
+     * See <a href="http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/keytool.html#Commands">options</a>.
+     *
+     * @since 1.6
+     */
+    @Parameter
+    private List<String> exts;
 
     /**
      * Distinguished name.
@@ -113,7 +129,11 @@ public class GenerateCertificateRequestMojo
         KeyToolGenerateCertificateRequestRequest request = super.createKeytoolRequest();
 
         request.setSigalg( this.sigalg );
-        request.setExt( this.ext );
+        if (this.exts != null && !this.exts.isEmpty()) {
+            request.setExts(exts);
+        } else {
+            request.setExt(ext);
+        }
         request.setDname( this.dname );
         request.setFile( this.file );
         request.setKeypass( this.keypass );

--- a/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateKeyPairMojo.java
+++ b/keytool-maven-plugin/src/main/java/org/codehaus/mojo/keytool/GenerateKeyPairMojo.java
@@ -24,6 +24,9 @@ import org.codehaus.mojo.keytool.requests.KeyToolGenerateKeyPairRequest;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * To generate a key pair into a keystore.
@@ -108,9 +111,21 @@ public class GenerateKeyPairMojo
      * See <a href="http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/keytool.html#Commands">options</a>.
      *
      * @since 1.2
+     *
+     * @deprecated Use {@link #exts instead}.
+     */
+    @Deprecated
+    private String ext;
+
+    /**
+     * X.509 extension.
+     * <p/>
+     * See <a href="http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/keytool.html#Commands">options</a>.
+     *
+     * @since 1.6
      */
     @Parameter
-    private String ext;
+    private List<String> exts;
 
     /**
      * Distinguished name.
@@ -174,7 +189,11 @@ public class GenerateKeyPairMojo
         request.setSigalg( this.sigalg );
         request.setDname( this.dname );
         request.setStartdate( this.startdate );
-        request.setExt( this.ext );
+        if (this.exts != null && !this.exts.isEmpty()) {
+            request.setExts(exts);
+        } else {
+            request.setExt(ext);
+        }
         request.setValidity( this.validity );
         return request;
     }


### PR DESCRIPTION
Closes https://github.com/mojohaus/keytool/issues/7

Previously only a single `<ext>` was permitted. You can now alternatively use:
```
<exts>
   <ext></ext>
</exts>
```
The previous behaviour is preserved and so this should be backwards compatible.