### PR TITLE
[#35] define plexus-plugin-version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,6 @@
     </contributor>
   </contributors>
 
-  <prerequisites>
-    <maven>${mavenVersion}</maven>
-  </prerequisites>
-
   <modules>
     <module>keytool-api</module>
     <module>keytool-api-test</module>
@@ -203,6 +199,11 @@
           <configuration>
             <scmBranch>gh-pages</scmBranch> <!-- branch where to deploy -->
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-maven-plugin</artifactId>
+          <version>1.3.8</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
- Remove prerequisites for parent, not a maven-plugin.

Fixes #35 (when applied together with https://github.com/mojohaus/keytool/pull/33)