### PR TITLE
[#40] CI update, builds with IBM Semeru and Java 11, 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,13 +21,39 @@ on: [push, pull_request]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn --batch-mode --show-version --errors verify -P run-its
+
+  build-all:
+    needs: build
 
     strategy:
       matrix:
-        # windows-latest
-        os: [ubuntu-latest, macOS-latest]
-        java: [8]
-        jdk: [temurin, zulu]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        java: [8, 11, 17]
+        # switch to semeru after: https://github.com/actions/setup-java/pull/289
+        jdk: [temurin, zulu, adopt-openj9]
+        exclude:
+          # was already built
+          - os: ubuntu-latest
+            java: 11
+            jdk: temurin
+          # not ready yet, only as semeru
+          - java: 17
+            jdk: adopt-openj9
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -44,4 +70,4 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn verify -e -B -V -P run-its
+        run: mvn --batch-mode --show-version --errors verify -P run-its


### PR DESCRIPTION
Some hints:

* Because these are a lot of builds, I did a pre-step with only Java 8 Temurin. If that fails, no need to build the others.
* The others use the matrix as expected. Excluded: The build which was already done.
* Build with IBM Semeru is a bit special. In contrast to Zulu and Temurin, it is not based on hotspot but Eclipse OpenJ9 and might have different encryption settings: algorithm aliases, defaults, etc.
Therefore I consider it highly valuable for anything security-related.
* Build with recent JDKs should be a no-brainer.
* I recommend to exclude some Mac builds to speed up the build.
* Semeru is not ready yet (https://github.com/actions/setup-java/pull/289), using adopt-openj9 until then.
